### PR TITLE
Prompt for uninstall cleanup properly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    infect (1.0.0)
+    infect (1.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -42,4 +42,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.13.5
+   1.13.6

--- a/lib/infect/cleanup.rb
+++ b/lib/infect/cleanup.rb
@@ -9,7 +9,7 @@ module Infect
     end
 
     def call
-      Dir["#{PACK_DIR}*/*/*"].each do |path|
+      install_paths.each do |path|
         unless names.include? File.basename(path)
           if confirm(path)
             notice "Deleting #{path}"
@@ -35,6 +35,21 @@ module Infect
           false
         end
       end
+    end
+
+    private
+
+    def install_paths
+      # Get the list of directories that plugins might be installed to, since
+      # we install legacy plugins in a special directory we want to look under
+      # that as well as in the top level `pack` directory.
+
+      default_dir = Command::Plugin::DEFAULT_DIR
+      plugins = Dir["#{PACK_DIR}#{default_dir}/*/*"]
+      packages = Dir["#{PACK_DIR}*"]
+      packages.delete("#{PACK_DIR}#{default_dir}")
+
+      plugins + packages
     end
 
   end

--- a/lib/infect/command/plugin.rb
+++ b/lib/infect/command/plugin.rb
@@ -3,11 +3,13 @@ require 'open3'
 module Infect
   class Command
     class Plugin < Command
+      DEFAULT_DIR = "plugins"
+
       attr_reader :build, :location, :name, :options, :url
 
       def initialize(arg, opts)
         load = opts.fetch(:load) { "start" }
-        package = opts.fetch(:package) { "default" }
+        package = opts.fetch(:package) { DEFAULT_DIR }
 
         @name = File.basename(arg)
         @url = "git@github.com:#{arg}.git"

--- a/lib/infect/version.rb
+++ b/lib/infect/version.rb
@@ -1,3 +1,3 @@
 module Infect
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
When globbing for `*/*/*` under the pack directory we could potentially prompt for every file that is part of a proper vim package, which made the infect cleanup process noisy to the point of uselessness.

Now will search two directorys:

* `.vim/pack/plugins/*/*`
* `.vim/pack/*`

But not `.vim/pack/plugins`, since that is our default "legacy plugin" folder.

There should only ever be "auto" and "opt" at the root of `.vim/pack/plugins/*` so I just globbed for everything there.