### PR TITLE
Add --help and --version CLI flags

### DIFF
--- a/bin/infect
+++ b/bin/infect
@@ -1,4 +1,21 @@
 #!/usr/bin/env ruby
 require "#{File.dirname(__FILE__)}/../lib/infect"
 
+unless (ARGV & %w[-v --version]).empty?
+  puts "infect version #{Infect::VERSION}"
+  exit 0
+end
+
+unless (ARGV & %w[-h --help]).empty?
+  puts "Command line tool for installing packages for Vim"
+  puts "Usage: infect [options]"
+  puts "Options:"
+  puts "    -f            Force removal of old packages without prompting"
+  puts "    -v/--version  Print the version"
+  puts "    -h/--help     Print this message"
+  puts ""
+  puts "See https://github.com/csexton/infect for instructions"
+  exit 0
+end
+
 Infect::Runner.call(*ARGV)


### PR DESCRIPTION
Trying to be a good command line citizen.

```
 % ./bin/infect -h
Command line tool for installing packages for Vim
Usage: infect [options]
Options:
    -f            Force removal of old packages without prompting
    -v/--version  Print the version
    -h/--help     Print this message

See https://github.com/csexton/infect for instructions

 % ./bin/infect -v
infect version 1.1.0
```