### PR TITLE
Use `git pull` for updating repos

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    infect (1.1.0)
+    infect (1.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -42,4 +42,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.13.6
+   1.15.3

--- a/lib/infect/command/plugin.rb
+++ b/lib/infect/command/plugin.rb
@@ -28,8 +28,7 @@ module Infect
       def update
         notice "Updating #{name}..."
         chdir location
-        git "fetch"
-        git "checkout master"
+        git "pull"
       end
 
       def call

--- a/lib/infect/version.rb
+++ b/lib/infect/version.rb
@@ -1,3 +1,3 @@
 module Infect
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/standalone/infect
+++ b/standalone/infect
@@ -99,8 +99,7 @@ module Infect
       def update
         notice "Updating #{name}..."
         chdir location
-        git "fetch"
-        git "checkout master"
+        git "pull"
       end
 
       def call
@@ -230,7 +229,7 @@ module Infect
 
   class Runner
     def self.call(*args)
-      self.new.call(args)
+      self.new.call(*args)
     end
 
     def call(*args)


### PR DESCRIPTION
The `fetch` then `checkout` process didn't do anything useful, so this reverts the update process to use `pull`.

Regenerate the standalone script (which was stale anyway), and bump the version.